### PR TITLE
Use keyword to generate src dirs from project config

### DIFF
--- a/lib/mr_t/config.ex
+++ b/lib/mr_t/config.ex
@@ -38,8 +38,8 @@ defmodule MrT.Config do
 
   defp src_dirs(false) do
     Mix.Project.config
-    |> Map.take([:elixirc_paths, :erlc_paths, :erlc_include_path])
-    |> Map.values
+    |> Keyword.take([:elixirc_paths, :erlc_paths, :erlc_include_path])
+    |> Keyword.values
     |> List.flatten
     |> Enum.map(&Path.join app_source_dir(), &1)
     |> Enum.filter(&File.exists?/1)


### PR DESCRIPTION
I was having an issue where MrT was no longer doing code reloading or test running when src files were changed.

The issue was in the generation of the src directories.  Mix.Project.Config returns a Keyword per the Mix docs here: https://hexdocs.pm/mix/Mix.Project.html#config/0

I checked the docs back to 1.3 and it looks like Keyword is being used in that version as well.

This version is working for our project using Elixir 1.6.

Please let me know if you have any questions or need further changes.